### PR TITLE
reference flip angle selection fix

### DIFF
--- a/+qb/+workers/VFAprepWorker.m
+++ b/+qb/+workers/VFAprepWorker.m
@@ -165,7 +165,8 @@ methods
                 end
 
                 % Define a reference volume, i.e. the middle FA file (assume TR and nii-header identical for all MPM/VFAs of the same run)
-                flip = round(mean(str2double(flips)));
+                flips_sorted = sort(str2double(flips));
+                flip = flips_sorted(round(length(flips)/2));
                 Vref = spm_vol(char(obj.query_ses(obj.BIDS, 'data', bfilter_e1, flip=flip)));
 
                 % Compute T1 and M0 maps


### PR DESCRIPTION
The previous code selected the mean flip angle (FA) in the VFAprepWorker as the reference FA. However that has both the assumption of an uneven amount of flip angles and a symmetrical distribution of FAs arround the mean FA. I don't think that this is necessarily always the case, i.e. our sequence has [10 20 50 70]. This also demonstrates that replacing mean by median wont do the trick, as the median of that sequence is defined as 35 and therefore not present among the FAs collected. My changes select the middle flip angle (rounded in even cases) as reference FA. I presume this would be a valid choice, but please correct me on that.