### PR TITLE
Skip single-FA acquisitions and reset flipangles per acq

### DIFF
--- a/+qb/+workers/VFAprepWorker.m
+++ b/+qb/+workers/VFAprepWorker.m
@@ -158,7 +158,9 @@ methods
                 VFA_e1     = obj.query_ses(obj.BIDS, 'data',  bfilter_e1);
                 flips      = obj.query_ses(obj.BIDS, 'flips', bfilter_e1);
                 if length(VFA_e1) <= 1
-                    obj.logger.error("Need at least two different flip angles to compute T1 and S0 maps, found:" + VFA_e1)
+                    %obj.logger.error("Need at least two different flip angles to compute T1 and S0 maps, found:" + VFA_e1)
+                    obj.logger.info("Skipping acq-%s: need at least two flip angles for despot1, found %d", char(acq), length(VFA_e1))
+                    continue
                 end
                 if length(VFA_e1) ~= length(flips)
                     obj.logger.error("Number of VFA images found (%d) differs from the number of flipangles (%d)", length(VFA_e1), length(flips))
@@ -170,6 +172,7 @@ methods
 
                 % Compute T1 and M0 maps
                 obj.logger.info("--> Running despot1 to compute T1 and M0 maps from: " + VFA_e1{1})
+                flipangles = [];
                 VFAimg = NaN([Vref.dim length(VFA_e1)]);
                 for n = 1:length(VFA_e1)
                     VFAn = spm_vol(VFA_e1{n});
@@ -231,6 +234,11 @@ methods
             for run = str2double(obj.query_ses(obj.BIDS, 'runs', bfilter))
 
                 bfilter_e1 = setfields(bfilter, echo=1, run=run, part='mag');
+                
+                % Skip acquisitions with fewer than 2 flip angles (no synthetic T1 was produced in step 1)
+                if length(obj.query_ses(obj.BIDS, 'flips', bfilter_e1)) <= 1
+                    continue
+                end
 
                 % Get the denoised data (if applicable)
                 if strlength(obj.config.(obj.name).denoising.method)


### PR DESCRIPTION
1. The existing error check for acquisitions with only one flip angle logs an error but does not skip to the next acquisition. As a result, processing continues and crashes in despot1_mapping. This fix logs an informational message and skips single-FA acquisitions.
2. flipangles was not cleared between acquisition iterations. If populated with n values in one iteration and fewer values (e.g., n−2) in the next, only the first n−2 entries were overwritten, leaving stale values in the remaining positions. This is now fixed by reinitializing flipangles per acquisition.

3. Acquisitions with fewer than two flip angles are now skipped, since no synthetic T1 was generated in step 1.